### PR TITLE
Allow plugin to work on pages with no footer

### DIFF
--- a/stickyMojo.js
+++ b/stickyMojo.js
@@ -5,7 +5,7 @@
       var settings = $.extend({
         'footerID': '',
         'contentID': '',
-        'orientation': $(this).css('float'),
+        'orientation': $(this).css('float')
       }, options);
 
       var sticky = {


### PR DESCRIPTION
For those of us who would like to use this plugin on sites that do not have a footer, it would be nice if we didn't have to add a blank/placeholder one. This simple change should add support for this, or if you have a better way that'd be great too.  Thanks for making a nice, lean plugin for this; I'm enjoying using it.
