### PR TITLE
Add support for pages that do not have a footer

### DIFF
--- a/stickyMojo.js
+++ b/stickyMojo.js
@@ -50,6 +50,7 @@
       function cacheElements() {
         settings.footerID = $(settings.footerID);
         settings.contentID = $(settings.contentID);
+        settings.document = $(document);
       }
 
       //  Calcualtes the limits top and bottom limits for the sidebar
@@ -57,7 +58,7 @@
         return {
           limit: settings.footerID.length ? 
             settings.footerID.offset().top - sticky.stickyHeight :
-            $(document).height(),
+            settings.document.height(),
           windowTop: sticky.win.scrollTop(),
           stickyTop: sticky.stickyTop2 - sticky.marg
         }


### PR DESCRIPTION
For those of us who would like to use this plugin on sites that do not have a footer, it would be nice if we didn't have to add a blank/placeholder one. This simple change should add support for this, or if you have a better way that'd be great too. Thanks for making a nice, lean plugin for this; I'm enjoying using it.
