### PR TITLE
Added option to set top offset when position is fixed

### DIFF
--- a/stickyMojo.js
+++ b/stickyMojo.js
@@ -5,7 +5,8 @@
       var settings = $.extend({
         'footerID': '',
         'contentID': '',
-        'orientation': $(this).css('float')
+        'orientation': $(this).css('float'),
+        'fixedPositionTopOffset' : 0
       }, options);
 
       var sticky = {
@@ -65,7 +66,7 @@
       function setFixedSidebar() {
         sticky.el.css({
           position: 'fixed',
-          top: 0
+          top: settings.fixedPositionTopOffset
         });
       }
 


### PR DESCRIPTION
I've added the ability to set the top offset when the position is fixed.  This fixes issue #4 and gives greater flexibility when you don't want to set a margin-top on the sticky slider.
