### PR TITLE
bind 'stick' additionally to 'load'

### DIFF
--- a/stickyMojo.js
+++ b/stickyMojo.js
@@ -31,6 +31,7 @@
           sticky.el.css('left', sticky.stickyLeft);
 
           sticky.win.bind({
+            'load': stick,
             'scroll': stick,
             'resize': function() {
               sticky.el.css('left', sticky.stickyLeft);


### PR DESCRIPTION
fix for: opening a URL with an anchor (http://example.org#example) did
not update the sticky content (as no scroll or resize occurs)
