### PR TITLE
Fix case sensitivity issues with bower.json 'main'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "stickymojo",
-  "main": "stickymojo.js",
+  "main": "stickyMojo.js",
   "version": "1.0.0",
   "homepage": "http://mojotech.github.io/stickymojo/",
   "authors": [


### PR DESCRIPTION
"stickymojo.js" doesn't exist on case-sensitive file systems and languages.